### PR TITLE
Add index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,9 @@
+module.exports = function(opts) {
+  var implicit = (opts && opts.implicit == false) ? false : true;
+
+  return function(style){
+    style.include(__dirname);
+    if (implicit) { style.import('index.styl'); }
+  }
+
+}


### PR DESCRIPTION
It creates an index.js to include the index.styl using Stylus API.

Then we can simply install this package via NPM and include into our Stylus project using the `use` method. It's very useful when we are using tools like Grunt and Gulp, so we can import the `styus-triangle` into our project like this way:

``` javascript
gulp.task('stylus', function () {
  gulp.src('./css/test.styl')
    .pipe(stylus({
      use: [
        require('stylus-triangle')()
      ]
    }))
    .pipe(gulp.dest('./css/build'));
});

```
